### PR TITLE
INFOPLAT-1575 Implement metric scraper from prometheus.Gatherer 

### DIFF
--- a/scrape/manager_test.go
+++ b/scrape/manager_test.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"net/url"
 	"os"
 	"strconv"
@@ -780,29 +779,30 @@ func TestManagerCTZeroIngestion(t *testing.T) {
 
 			once := sync.Once{}
 			// Start fake HTTP target to that allow one scrape only.
-			server := httptest.NewServer(
-				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					fail := true
-					once.Do(func() {
-						fail = false
-						w.Header().Set("Content-Type", `application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited`)
 
-						ctrType := dto.MetricType_COUNTER
-						w.Write(protoMarshalDelimited(t, &dto.MetricFamily{
-							Name:   proto.String(mName),
-							Type:   &ctrType,
-							Metric: []*dto.Metric{{Counter: tc.counterSample}},
-						}))
-					})
+			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				fail := true
+				once.Do(func() {
+					fail = false
+					w.Header().Set("Content-Type", `application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited`)
 
-					if fail {
-						w.WriteHeader(http.StatusInternalServerError)
-					}
-				}),
-			)
-			defer server.Close()
+					ctrType := dto.MetricType_COUNTER
+					w.Write(protoMarshalDelimited(t, &dto.MetricFamily{
+						Name:   proto.String(mName),
+						Type:   &ctrType,
+						Metric: []*dto.Metric{{Counter: tc.counterSample}},
+					}))
+				})
 
-			serverURL, err := url.Parse(server.URL)
+				if fail {
+					w.WriteHeader(http.StatusInternalServerError)
+				}
+			})
+			// This enables scraper to read metrics from the handler directly without making HTTP request
+			SetDefaultGathererHandler(handler)
+			defer SetDefaultGathererHandler(nil)
+
+			serverURL, err := url.Parse("http://not-started:8080")
 			require.NoError(t, err)
 
 			// Add fake target directly into tsets + reload. Normally users would use

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -2048,8 +2048,8 @@ func (gs *gathererScraper) scrape(ctx context.Context) (*http.Response, error) {
 	}
 }
 
+// Implements http.ResponseWriter.
 type responseWriter struct {
-	http.ResponseWriter
 	response *http.Response
 	// Writes to response body
 	w io.Writer

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-kit/log"
@@ -36,6 +37,8 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/version"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"github.com/prometheus/prometheus/model/exemplar"
@@ -318,14 +321,14 @@ func (sp *scrapePool) restartLoops(reuseCache bool) {
 		t := sp.activeTargets[fp]
 		interval, timeout, err := t.intervalAndTimeout(interval, timeout)
 		var (
-			s = &targetScraper{
+			s = newScraper(&targetScraper{
 				Target:               t,
 				client:               sp.client,
 				timeout:              timeout,
 				bodySizeLimit:        bodySizeLimit,
 				acceptHeader:         acceptHeader(sp.config.ScrapeProtocols),
 				acceptEncodingHeader: acceptEncodingHeader(enableCompression),
-			}
+			})
 			newLoop = sp.newLoop(scrapeLoopOptions{
 				target:                   t,
 				scraper:                  s,
@@ -462,7 +465,7 @@ func (sp *scrapePool) sync(targets []*Target) {
 			// for every target.
 			var err error
 			interval, timeout, err = t.intervalAndTimeout(interval, timeout)
-			s := &targetScraper{
+			s := newScraper(&targetScraper{
 				Target:               t,
 				client:               sp.client,
 				timeout:              timeout,
@@ -470,7 +473,7 @@ func (sp *scrapePool) sync(targets []*Target) {
 				acceptHeader:         acceptHeader(sp.config.ScrapeProtocols),
 				acceptEncodingHeader: acceptEncodingHeader(enableCompression),
 				metrics:              sp.metrics,
-			}
+			})
 			l := sp.newLoop(scrapeLoopOptions{
 				target:                   t,
 				scraper:                  s,
@@ -709,6 +712,13 @@ type targetScraper struct {
 	metrics *scrapeMetrics
 }
 
+func newScraper(ts *targetScraper) scraper {
+	if handler := GetDefaultGathererHandler(); handler != nil {
+		return &gathererScraper{ts, handler}
+	}
+	return ts
+}
+
 var errBodySizeLimit = errors.New("body size limit exceeded")
 
 // acceptHeader transforms preference from the options into specific header values as
@@ -735,7 +745,7 @@ func acceptEncodingHeader(enableCompression bool) string {
 
 var UserAgent = fmt.Sprintf("Prometheus/%s", version.Version)
 
-func (s *targetScraper) scrape(ctx context.Context) (*http.Response, error) {
+func (s *targetScraper) scrapeRequest() (*http.Request, error) {
 	if s.req == nil {
 		req, err := http.NewRequest(http.MethodGet, s.URL().String(), nil)
 		if err != nil {
@@ -748,8 +758,15 @@ func (s *targetScraper) scrape(ctx context.Context) (*http.Response, error) {
 
 		s.req = req
 	}
+	return s.req, nil
+}
 
-	return s.client.Do(s.req.WithContext(ctx))
+func (s *targetScraper) scrape(ctx context.Context) (*http.Response, error) {
+	req, err := s.scrapeRequest()
+	if err != nil {
+		return nil, err
+	}
+	return s.client.Do(req.WithContext(ctx))
 }
 
 func (s *targetScraper) readResponse(ctx context.Context, resp *http.Response, w io.Writer) (string, error) {
@@ -1995,4 +2012,91 @@ func pickSchema(bucketFactor float64) int32 {
 	default:
 		return int32(floor)
 	}
+}
+
+// Scraper implementation that fetches metrics data from Gatherer http.Handler.
+type gathererScraper struct {
+	*targetScraper
+	h http.Handler
+}
+
+type scrapeResult struct {
+	resp *http.Response
+	err  error
+}
+
+func (gs *gathererScraper) scrape(ctx context.Context) (*http.Response, error) {
+	resCh := make(chan scrapeResult, 1)
+	go func() {
+		defer close(resCh)
+		req, err := gs.scrapeRequest()
+		if err != nil {
+			resCh <- scrapeResult{nil, err}
+			return
+		}
+		w := newResponseWriter(req)
+		if gs.h != nil {
+			gs.h.ServeHTTP(w, req)
+		}
+		resCh <- scrapeResult{w.response, nil}
+	}()
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case r := <-resCh:
+		return r.resp, r.err
+	}
+}
+
+type responseWriter struct {
+	http.ResponseWriter
+	response *http.Response
+	// Writes to response body
+	w io.Writer
+}
+
+func newResponseWriter(req *http.Request) *responseWriter {
+	buf := new(bytes.Buffer)
+
+	return &responseWriter{
+		w: io.Writer(buf),
+		response: &http.Response{
+			Status:     http.StatusText(http.StatusOK),
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(buf),
+			Request:    req,
+		},
+	}
+}
+
+func (rw *responseWriter) Header() http.Header {
+	return rw.response.Header
+}
+
+func (rw *responseWriter) Write(data []byte) (int, error) {
+	return rw.w.Write(data)
+}
+
+func (rw *responseWriter) WriteHeader(statusCode int) {
+	rw.response.StatusCode = statusCode
+	rw.response.Status = fmt.Sprintf("%d %s", statusCode, http.StatusText(statusCode))
+}
+
+var defaultGathererHandler atomic.Pointer[http.Handler]
+
+// This enables scraper to read metrics from the handler directly without making HTTP request
+func SetDefaultGathererHandler(h http.Handler) {
+	defaultGathererHandler.Store(&h)
+}
+
+func SetDefaultGatherer(g prometheus.Gatherer) {
+	SetDefaultGathererHandler(promhttp.HandlerFor(g, promhttp.HandlerOpts{}))
+}
+
+func GetDefaultGathererHandler() http.Handler {
+	if h := defaultGathererHandler.Load(); h != nil {
+		return *h
+	}
+	return nil
 }

--- a/scrape/scrape_test.go
+++ b/scrape/scrape_test.go
@@ -2333,6 +2333,20 @@ func TestScrapeLoopOutOfBoundsTimeError(t *testing.T) {
 	require.Equal(t, 0, seriesAdded)
 }
 
+const useGathererHandler = true
+
+func newHTTPTestServer(handler http.Handler) *httptest.Server {
+	if useGathererHandler {
+		server := httptest.NewUnstartedServer(handler)
+		server.URL = "http://not-started:8080"
+		SetDefaultGathererHandler(handler)
+		return server
+	}
+	server := httptest.NewServer(handler)
+	SetDefaultGathererHandler(nil)
+	return server
+}
+
 func TestTargetScraperScrapeOK(t *testing.T) {
 	const (
 		configTimeout   = 1500 * time.Millisecond
@@ -2341,7 +2355,7 @@ func TestTargetScraperScrapeOK(t *testing.T) {
 
 	var protobufParsing bool
 
-	server := httptest.NewServer(
+	server := newHTTPTestServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if protobufParsing {
 				accept := r.Header.Get("Accept")
@@ -2357,6 +2371,7 @@ func TestTargetScraperScrapeOK(t *testing.T) {
 		}),
 	)
 	defer server.Close()
+	defer SetDefaultGathererHandler(nil)
 
 	serverURL, err := url.Parse(server.URL)
 	if err != nil {
@@ -2364,7 +2379,7 @@ func TestTargetScraperScrapeOK(t *testing.T) {
 	}
 
 	runTest := func(acceptHeader string) {
-		ts := &targetScraper{
+		ts := newScraper(&targetScraper{
 			Target: &Target{
 				labels: labels.FromStrings(
 					model.SchemeLabel, serverURL.Scheme,
@@ -2374,7 +2389,7 @@ func TestTargetScraperScrapeOK(t *testing.T) {
 			client:       http.DefaultClient,
 			timeout:      configTimeout,
 			acceptHeader: acceptHeader,
-		}
+		})
 		var buf bytes.Buffer
 
 		resp, err := ts.scrape(context.Background())
@@ -2393,19 +2408,20 @@ func TestTargetScraperScrapeOK(t *testing.T) {
 func TestTargetScrapeScrapeCancel(t *testing.T) {
 	block := make(chan struct{})
 
-	server := httptest.NewServer(
+	server := newHTTPTestServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			<-block
 		}),
 	)
 	defer server.Close()
+	defer SetDefaultGathererHandler(nil)
 
 	serverURL, err := url.Parse(server.URL)
 	if err != nil {
 		panic(err)
 	}
 
-	ts := &targetScraper{
+	ts := newScraper(&targetScraper{
 		Target: &Target{
 			labels: labels.FromStrings(
 				model.SchemeLabel, serverURL.Scheme,
@@ -2414,7 +2430,7 @@ func TestTargetScrapeScrapeCancel(t *testing.T) {
 		},
 		client:       http.DefaultClient,
 		acceptHeader: acceptHeader(config.DefaultGlobalConfig.ScrapeProtocols),
-	}
+	})
 	ctx, cancel := context.WithCancel(context.Background())
 
 	errc := make(chan error, 1)
@@ -2448,19 +2464,20 @@ func TestTargetScrapeScrapeCancel(t *testing.T) {
 }
 
 func TestTargetScrapeScrapeNotFound(t *testing.T) {
-	server := httptest.NewServer(
+	server := newHTTPTestServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusNotFound)
 		}),
 	)
 	defer server.Close()
+	defer SetDefaultGathererHandler(nil)
 
 	serverURL, err := url.Parse(server.URL)
 	if err != nil {
 		panic(err)
 	}
 
-	ts := &targetScraper{
+	ts := newScraper(&targetScraper{
 		Target: &Target{
 			labels: labels.FromStrings(
 				model.SchemeLabel, serverURL.Scheme,
@@ -2469,11 +2486,12 @@ func TestTargetScrapeScrapeNotFound(t *testing.T) {
 		},
 		client:       http.DefaultClient,
 		acceptHeader: acceptHeader(config.DefaultGlobalConfig.ScrapeProtocols),
-	}
+	})
 
 	resp, err := ts.scrape(context.Background())
 	require.NoError(t, err)
 	_, err = ts.readResponse(context.Background(), resp, io.Discard)
+	require.Error(t, err)
 	require.Contains(t, err.Error(), "404", "Expected \"404 NotFound\" error but got: %s", err)
 }
 
@@ -2483,7 +2501,7 @@ func TestTargetScraperBodySizeLimit(t *testing.T) {
 		responseBody  = "metric_a 1\nmetric_b 2\n"
 	)
 	var gzipResponse bool
-	server := httptest.NewServer(
+	server := newHTTPTestServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", `text/plain; version=0.0.4`)
 			if gzipResponse {
@@ -2497,6 +2515,7 @@ func TestTargetScraperBodySizeLimit(t *testing.T) {
 		}),
 	)
 	defer server.Close()
+	defer SetDefaultGathererHandler(nil)
 
 	serverURL, err := url.Parse(server.URL)
 	if err != nil {
@@ -2515,37 +2534,38 @@ func TestTargetScraperBodySizeLimit(t *testing.T) {
 		acceptHeader:  acceptHeader(config.DefaultGlobalConfig.ScrapeProtocols),
 		metrics:       newTestScrapeMetrics(t),
 	}
+	s := newScraper(ts)
 	var buf bytes.Buffer
 
 	// Target response uncompressed body, scrape with body size limit.
-	resp, err := ts.scrape(context.Background())
+	resp, err := s.scrape(context.Background())
 	require.NoError(t, err)
-	_, err = ts.readResponse(context.Background(), resp, &buf)
+	_, err = s.readResponse(context.Background(), resp, &buf)
 	require.ErrorIs(t, err, errBodySizeLimit)
 	require.Equal(t, bodySizeLimit, buf.Len())
 	// Target response gzip compressed body, scrape with body size limit.
 	gzipResponse = true
 	buf.Reset()
-	resp, err = ts.scrape(context.Background())
+	resp, err = s.scrape(context.Background())
 	require.NoError(t, err)
-	_, err = ts.readResponse(context.Background(), resp, &buf)
+	_, err = s.readResponse(context.Background(), resp, &buf)
 	require.ErrorIs(t, err, errBodySizeLimit)
 	require.Equal(t, bodySizeLimit, buf.Len())
 	// Target response uncompressed body, scrape without body size limit.
 	gzipResponse = false
 	buf.Reset()
 	ts.bodySizeLimit = 0
-	resp, err = ts.scrape(context.Background())
+	resp, err = s.scrape(context.Background())
 	require.NoError(t, err)
-	_, err = ts.readResponse(context.Background(), resp, &buf)
+	_, err = s.readResponse(context.Background(), resp, &buf)
 	require.NoError(t, err)
 	require.Len(t, responseBody, buf.Len())
 	// Target response gzip compressed body, scrape without body size limit.
 	gzipResponse = true
 	buf.Reset()
-	resp, err = ts.scrape(context.Background())
+	resp, err = s.scrape(context.Background())
 	require.NoError(t, err)
-	_, err = ts.readResponse(context.Background(), resp, &buf)
+	_, err = s.readResponse(context.Background(), resp, &buf)
 	require.NoError(t, err)
 	require.Len(t, responseBody, buf.Len())
 }
@@ -3062,7 +3082,7 @@ func TestScrapeReportLimit(t *testing.T) {
 		scrapedTwice = make(chan bool)
 	)
 
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := newHTTPTestServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, "metric_a 44\nmetric_b 44\nmetric_c 44\nmetric_d 44\n")
 		scrapes++
 		if scrapes == 2 {
@@ -3070,6 +3090,7 @@ func TestScrapeReportLimit(t *testing.T) {
 		}
 	}))
 	defer ts.Close()
+	defer SetDefaultGathererHandler(nil)
 
 	sp, err := newScrapePool(cfg, s, 0, nil, nil, &Options{}, newTestScrapeMetrics(t))
 	require.NoError(t, err)
@@ -3310,7 +3331,7 @@ test_summary_count 199
 	scrapeCount := 0
 	scraped := make(chan bool)
 
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := newHTTPTestServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, metricsText)
 		scrapeCount++
 		if scrapeCount > 2 {
@@ -3318,6 +3339,7 @@ test_summary_count 199
 		}
 	}))
 	defer ts.Close()
+	defer SetDefaultGathererHandler(nil)
 
 	sp, err := newScrapePool(config, simpleStorage, 0, nil, nil, &Options{}, newTestScrapeMetrics(t))
 	require.NoError(t, err)
@@ -3435,7 +3457,7 @@ func TestScrapeLoopCompression(t *testing.T) {
 		t.Run(fmt.Sprintf("compression=%v,acceptEncoding=%s", tc.enableCompression, tc.acceptEncoding), func(t *testing.T) {
 			scraped := make(chan bool)
 
-			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ts := newHTTPTestServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				require.Equal(t, tc.acceptEncoding, r.Header.Get("Accept-Encoding"), "invalid value of the Accept-Encoding header")
 				fmt.Fprint(w, metricsText)
 				close(scraped)
@@ -3596,7 +3618,7 @@ func BenchmarkTargetScraperGzip(b *testing.B) {
 
 	for _, scenario := range scenarios {
 		b.Run(fmt.Sprintf("metrics=%d", scenario.metricsCount), func(b *testing.B) {
-			ts := &targetScraper{
+			ts := newScraper(&targetScraper{
 				Target: &Target{
 					labels: labels.FromStrings(
 						model.SchemeLabel, serverURL.Scheme,
@@ -3606,7 +3628,7 @@ func BenchmarkTargetScraperGzip(b *testing.B) {
 				},
 				client:  client,
 				timeout: time.Second,
-			}
+			})
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				_, err = ts.scrape(context.Background())
@@ -3705,7 +3727,7 @@ func testNativeHistogramMaxSchemaSet(t *testing.T, minBucketFactor string, expec
 	buffer := protoMarshalDelimited(t, histogramMetricFamily)
 
 	// Create a HTTP server to serve /metrics via ProtoBuf
-	metricsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	metricsServer := newHTTPTestServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", `application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited`)
 		w.Write(buffer)
 	}))


### PR DESCRIPTION
Implement scraper from prometheus.Gatherer.
Scraper fetches data directly from http.Handler created for the gatherer.

The code below will switch scraper to logic to make fake http request directly from promhttp Handler and fetch in memory metrics data from Gatherer instead of making HTTP requests. 

```
SetDefaultGatherer(prometheus.DefaultGatherer)
```

This will be used for custom Otel [prometheusreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusreceiver) implementation to convert Prometheus metrics to OTel metrics.

OTel `prometheus receiver` create `scrape.Manager` [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/prometheusreceiver/metrics_receiver.go#L169)

before:
```
scrapeManager, err := scrape.NewManager(opts, logger, store, r.registerer)
	if err != nil {
		return err
	}
``` 

after:
```
// Shortcuts scraper HTTP requests, fetch metrics data from the gatherer directly
scrape.SetDefaultGatherer(prometheus.DefaultGatherer) 

scrapeManager, err := scrape.NewManager(opts, logger, store, r.registerer)
	if err != nil {
		return err
	}
``` 
